### PR TITLE
Update currency_mappings.json

### DIFF
--- a/currency_mappings.json
+++ b/currency_mappings.json
@@ -17,7 +17,7 @@
     },
     "iL62spNN42Vqdxh8H5nrfNe8d6Amsnfkdx": {
       "address": "0x4f14E88B5037F0cA24348Fa707E4A7Ee5318d9d5",
-      "eth_symbol": "NATION",
+      "eth_symbol": "NATI",
       "vrsc_symbol": "NATI.vETH"
     },
     "i5w5MuNik5NtLcYmNzcvaoixooEebB6MGV": {
@@ -27,7 +27,7 @@
     },
     "i9nLSK4S1U5sVMq4eJUHR1gbFALz56J9Lj": {
       "address": "0x0655977FEb2f289A4aB78af67BAB0d17aAb84367",
-      "eth_symbol": "CRVUSD",
+      "eth_symbol": "SCRVUSD",
       "vrsc_symbol": "scrvUSD.vETH"
     },
     "iS8TfRPfVpKo5FVfSUzfHBQxo9KuzpnqLU": {


### PR DESCRIPTION
Fixed two incorrect names. NATION should be NATI and CRVUSD should be SCRVUSD as the scrvUSD contract address is used in the file. These issues were carried over from https://github.com/Fried333/verusapi_v2